### PR TITLE
pad leader base address of data with zero instead of space

### DIFF
--- a/MARC4J.Net/MarcStreamWriter.cs
+++ b/MARC4J.Net/MarcStreamWriter.cs
@@ -213,7 +213,7 @@ namespace MARC4J.Net
             output.Write(ldr.CharCodingScheme);
             output.Write(encoding.GetBytes(ldr.IndicatorCount.ToString()));
             output.Write(encoding.GetBytes(ldr.SubfieldCodeLength.ToString()));
-            output.Write(encoding.GetBytes(ldr.BaseAddressOfData.ToString().PadLeft(5, ' ')));
+            output.Write(encoding.GetBytes(ldr.BaseAddressOfData.ToString().PadLeft(5, '0')));
             output.Write(encoding.GetBytes(new String(ldr.ImplDefined2)));
             output.Write(encoding.GetBytes(new String(ldr.EntryMap)));
         }


### PR DESCRIPTION
When using MarcStreamWriter, the BaseAddressOfData field in the leader is not padded with zero '0', instead it is padded with space ' '.

We have found this causes an issue with a number of library management systems in that they are unable to read the marc records.

Other uses of the leader (ToString and the unit tests) correctly pad this field with zero.
