### PR TITLE
GetCharTable throws KeyNotFoundException

### DIFF
--- a/MARC4J.Net/Converter/ReverseCodeTableHash.cs
+++ b/MARC4J.Net/Converter/ReverseCodeTableHash.cs
@@ -51,7 +51,13 @@ namespace MARC4J.Net.Converter
 
         public override IDictionary<int, char[]> GetCharTable(char c)
         {
-            return charsets[c];
+            IDictionary<int, char[]> value = null;
+            if (charsets.TryGetValue(c, out value))
+            {
+                return value;
+            }
+
+            return null;
         }
 
         public ReverseCodeTableHash(Stream byteStream)


### PR DESCRIPTION
When a Unicode character is encountered that is not included in the default conversion code tables, a call to ReverseCodeTableHash.GetCharTable() throws a KeyNotFoundException.

The only method that calls GetCharTable is ReverseCodeTable.CodeTableHash()

Looking at usage of CodeTableHash, especially in ReverseCodeTable.CharHasMatch, it appears the correct outcome when a char is not found is to return null.

All other uses (except one) of CodeTableHash include a check for null on the returned value.
