### PR TITLE
 Allow setting encoding via the Encoding class in the constructor 

### DIFF
--- a/MARC4J.Net/MarcStreamWriter.cs
+++ b/MARC4J.Net/MarcStreamWriter.cs
@@ -53,7 +53,7 @@ namespace MARC4J.Net
 
         protected BinaryWriter output = null;
 
-        protected Encoding encoding = Encoding.GetEncoding("ISO-8859-1");
+        protected Encoding encoding;
 
         private CharConverter converter = null;
         protected bool allowOversizeEntry = false;
@@ -91,7 +91,7 @@ namespace MARC4J.Net
         /// <param name="output"></param>
         /// <param name="allowOversizeRecord"></param>
         public MarcStreamWriter(Stream output, bool allowOversizeRecord)
-            : this(output, null, allowOversizeRecord)
+            : this(output, "ISO-8859-1", allowOversizeRecord)
         {
         }
 
@@ -102,10 +102,26 @@ namespace MARC4J.Net
         /// <param name="output"></param>
         /// <param name="encoding"></param>
         /// <param name="allowOversizeRecord"></param>
-        public MarcStreamWriter(Stream output, String encoding, bool allowOversizeRecord)
+        public MarcStreamWriter(Stream output, String encoding, bool allowOversizeRecord) : this(output,
+            Encoding.GetEncoding(encoding), allowOversizeRecord)
         {
-            if (encoding != null)
-                this.encoding = Encoding.GetEncoding(encoding);
+        }
+
+        /// <summary>
+        /// Constructs an instance and creates a <code>Writer</code> object with
+        /// the specified output stream and character encoding.
+        /// </summary>
+        /// <param name="output"></param>
+        /// <param name="encoding"></param>
+        /// <param name="allowOversizeRecord"></param>
+        public MarcStreamWriter(Stream output, Encoding encoding, bool allowOversizeRecord)
+        {
+            if (encoding == null)
+            {
+                throw new ArgumentNullException("encoding", "null encoding");
+            }
+
+            this.encoding = encoding;
             this.output = new BinaryWriter(output);
             this.allowOversizeEntry = allowOversizeRecord;
         }

--- a/MARC4J.Net/MarcXmlWriter.cs
+++ b/MARC4J.Net/MarcXmlWriter.cs
@@ -63,7 +63,7 @@ namespace MARC4J.Net
         /// <param name="output"></param>
         /// <param name="indent"></param>
         public MarcXmlWriter(Stream output, bool indent)
-            : this(output, new UTF8Encoding(true), indent)
+            : this(output, "UTF-8", indent)
         {
         }
 

--- a/MARC4J.Net/MarcXmlWriter.cs
+++ b/MARC4J.Net/MarcXmlWriter.cs
@@ -36,8 +36,6 @@ namespace MARC4J.Net
 
         private XmlWriter writer = null;
 
-        private String encoding = "UTF-8";
-
         private CharConverter converter = null;
 
         private bool normalize = false;
@@ -65,7 +63,7 @@ namespace MARC4J.Net
         /// <param name="output"></param>
         /// <param name="indent"></param>
         public MarcXmlWriter(Stream output, bool indent)
-            : this(output, "UTF-8", indent)
+            : this(output, new UTF8Encoding(true), indent)
         {
         }
 
@@ -88,22 +86,33 @@ namespace MARC4J.Net
         /// <param name="encoding"></param>
         /// <param name="indent"></param>
         public MarcXmlWriter(Stream output, String encoding, bool indent)
+            : this(output, Encoding.GetEncoding(encoding), indent)
         {
-            this.encoding = encoding;
+        }
+
+        /// <summary>
+        /// Constructs an instance with the specified output stream, character
+        /// encoding and indentation.
+        /// </summary>
+        /// <param name="output"></param>
+        /// <param name="encoding"></param>
+        /// <param name="indent"></param>
+        public MarcXmlWriter(Stream output, Encoding encoding, bool indent)
+        {
             if (output == null)
             {
                 throw new ArgumentNullException("output", "null OutputStream");
             }
-            if (this.encoding == null)
+            if (encoding == null)
             {
                 throw new ArgumentNullException("encoding", "null encoding");
             }
             try
             {
                 this.indent = indent;
-                writer = XmlWriter.Create(output, new XmlWriterSettings()
+                writer = XmlWriter.Create(output, new XmlWriterSettings
                 {
-                    Encoding = Encoding.GetEncoding(encoding),
+                    Encoding = encoding,
                     Indent = indent
                 });
             }


### PR DESCRIPTION
I need to be able to write MarcXML without a BOM which can only be done by:
```cs
new UTF8Encoding(true)
```